### PR TITLE
Fix AttributeError from DoctestMarkdown

### DIFF
--- a/src/pytest_markdoctest/__init__.py
+++ b/src/pytest_markdoctest/__init__.py
@@ -127,7 +127,7 @@ class DoctestMarkdown(pytest.Module):
         name = self.path.name
         globs = {"__name__": "__main__"}
 
-        optionflags = get_optionflags(self)
+        optionflags = get_optionflags(self.config)
 
         runner = MarkDoctestRunner(
             verbose=False,


### PR DESCRIPTION
This PR fixes the `AttributeError: 'DoctestMarkdown' object has no attribute 'getini'` which I'm seeing `pytest` throw before even starting the doctests.